### PR TITLE
Handle reject when calling quit().

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,8 @@ module.exports = function (config) {
 	after(function (done) {
 		_nemo.driver.quit().then(function () {
 			done();
+		}, function (err) {
+			done(err);
 		});
 	});
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo-mocha-factory",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Mocha before/after functions for putting nemo into the global namespace",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This is causing the after() function to wait the entire timeout because `done` wasn't triggered on error cases.  (Resolves #2)