### PR TITLE
Update Copyright Holder

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 /*───────────────────────────────────────────────────────────────────────────*\
-│  Copyright (C) 2014 eBay Software Foundation                                │
+│  Copyright (C) 2014 PayPal                                                  │
 │                                                                             │
 │                                                                             │
 │   Licensed under the Apache License, Version 2.0 (the "License"); you may   │

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 /*───────────────────────────────────────────────────────────────────────────*\
-│  Copyright (C) 2014 eBay Software Foundation                                │
+│  Copyright (C) 2014 PayPal                                                  │
 │                                                                             │
 │                                                                             │
 │   Licensed under the Apache License, Version 2.0 (the "License"); you may   │


### PR DESCRIPTION
As part of the split earlier this year, copyright for this project was assigned from the eBay Software Foundation to PayPal.

Fixes #9 